### PR TITLE
Add FBA ficha generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # corazon-mexa-fba
+
+Este repositorio contiene scripts y utilidades para generar fichas de envíos FBA (Fulfillment by Amazon).
+
+## Uso del script `generar_ficha_fba.py`
+
+Ejemplo de uso:
+
+```bash
+python generar_ficha_fba.py --producto "Producto X" --sku 123ABC --cantidad 10 \
+    --precio 5.99 --destinatario "Cliente Ejemplo" --salida ficha.json
+```
+
+El script generará un archivo JSON con la información de la ficha y el costo total.
+

--- a/generar_ficha_fba.py
+++ b/generar_ficha_fba.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Genera una ficha para envíos FBA en formato JSON."""
+import argparse
+import json
+from datetime import datetime
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Genera una ficha FBA a partir de los datos proporcionados"
+    )
+    parser.add_argument("--producto", required=True, help="Nombre del producto")
+    parser.add_argument("--sku", required=True, help="SKU o identificador")
+    parser.add_argument("--cantidad", type=int, required=True, help="Cantidad")
+    parser.add_argument("--precio", type=float, required=True, help="Precio unitario")
+    parser.add_argument(
+        "--destinatario",
+        required=True,
+        help="Nombre del destinatario o cliente",
+    )
+    parser.add_argument(
+        "-o",
+        "--salida",
+        default="ficha_fba.json",
+        help="Archivo de salida (JSON)",
+    )
+    return parser.parse_args()
+
+
+def generar_ficha(args: argparse.Namespace) -> dict:
+    ficha = {
+        "fecha": datetime.now().isoformat(timespec="seconds"),
+        "producto": args.producto,
+        "sku": args.sku,
+        "cantidad": args.cantidad,
+        "precio_unitario": args.precio,
+        "destinatario": args.destinatario,
+        "costo_total": round(args.cantidad * args.precio, 2),
+    }
+    with open(args.salida, "w", encoding="utf-8") as f:
+        json.dump(ficha, f, indent=2, ensure_ascii=False)
+    return ficha
+
+
+def main() -> None:
+    args = parse_args()
+    ficha = generar_ficha(args)
+    print(f"Ficha guardada en {args.salida}")
+    print(json.dumps(ficha, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add README instructions for generating FBA fichas
- add `generar_ficha_fba.py` script to create JSON ficha files

## Testing
- `python generar_ficha_fba.py --producto "Producto X" --sku 123ABC --cantidad 10 --precio 5.0 --destinatario "Cliente" -o test.json`

------
https://chatgpt.com/codex/tasks/task_e_6844ed46c4f08333a78ef748a3ca801c